### PR TITLE
Add artist page

### DIFF
--- a/app/artist/model.js
+++ b/app/artist/model.js
@@ -1,5 +1,19 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
+  dataQuality: DS.attr('string'),
+  images: DS.attr(),
 
+  members: DS.hasMany('artist', {inverse: null}),
+  groups: DS.hasMany('artist', {inverse: null}),
+  aliases: DS.hasMany('artist', {inverse: null}),
+
+  name: DS.attr('string'),
+  realname: DS.attr('string'),
+  namevariations: DS.attr(),
+  profile: DS.attr('string'),
+  releasesUrl: DS.attr('string'),
+  resourceUrl: DS.attr('string'),
+  uri: DS.attr('string'),
+  urls: DS.attr(),
 });

--- a/app/artist/serializer.js
+++ b/app/artist/serializer.js
@@ -1,0 +1,21 @@
+import Serializer from '../application/serializer'
+
+export default Serializer.extend({
+  normalizeFindRecordResponse(store, primaryModelClass, payload, id, requestType) {
+    let newPayload = payload
+
+    if (payload.members) {
+      newPayload.members = payload.members.map(artist => artist.id)
+    }
+
+    if (payload.aliases) {
+      newPayload.aliases = payload.aliases.map(artist => artist.id)
+    }
+
+    if (payload.groups) {
+      newPayload.groups = payload.groups.map(artist => artist.id)
+    }
+
+    return this._super(store, primaryModelClass, newPayload, id, requestType)
+  }
+})

--- a/app/artist/template.hbs
+++ b/app/artist/template.hbs
@@ -1,1 +1,39 @@
+<h2>Artist</h2>
+<h1>{{model.name}}</h1>
+
+<p>real name: {{model.realname}}</p>
+<p>releasesUrl: {{model.releasesUrl}}</p>
+<p>url: {{model.resourceUrl}}</p>
+<p>{{model.profile}}</p>
+
+<p>name variations:</p>
+{{each-list list=model.namevariations}}
+
+<h3>Members (artists)</h3>
+{{#each-list list=model.members as |artist|}}
+  {{link-to artist.name "artist" artist}}
+{{else}}
+  nop
+{{/each-list}}
+
+<h3>Aliases (artists)</h3>
+{{#each-list list=model.aliases as |artist|}}
+  {{link-to artist.name "artist" artist}}
+{{/each-list}}
+
+<p>Groups (artists):</p>
+{{#each-list list=model.groups as |artist|}}
+  {{link-to artist.name "artist" artist}}
+{{/each-list}}
+
+<p>URLs:</p>
+{{each-list list=model.urls}}
+
+<h3>errors?</h3>
+{{#each model.errors.name as |error|}}
+  <div class="error">
+    {{error.message}}
+  </div>
+{{/each}}
+
 {{outlet}}

--- a/app/release/model.js
+++ b/app/release/model.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  // artists: DS.hasMany('artist')
+  artists: DS.hasMany('artist', {async: true}),
   // labels: DS.hasMany('label'),
   artistsSort: DS.attr('string'),
   country: DS.attr('string'),

--- a/app/release/serializer.js
+++ b/app/release/serializer.js
@@ -1,0 +1,13 @@
+import Serializer from '../application/serializer'
+
+export default Serializer.extend({
+  normalizeFindRecordResponse(store, primaryModelClass, payload, id, requestType) {
+    let newPayload = payload
+
+    if (payload.artists) {
+      newPayload.artists = payload.artists.map(artist => artist.id)
+    }
+
+    return this._super(store, primaryModelClass, newPayload, id, requestType)
+  }
+})

--- a/app/release/template.hbs
+++ b/app/release/template.hbs
@@ -26,6 +26,11 @@
 <p>Styles:</p>
 {{each-list list=model.styles}}
 
+<p>Artists:</p>
+{{#each-list list=model.artists as |artist|}}
+  {{link-to artist.name "artist" artist}}
+{{/each-list}}
+
 <p>Tracklist:</p>
 {{#each-list list=model.tracklist as |track|}}
   {{track.position}} -

--- a/tests/unit/artist/serializer-test.js
+++ b/tests/unit/artist/serializer-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | artist', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('artist');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = run(() => store.createRecord('artist', {}));
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});

--- a/tests/unit/release/serializer-test.js
+++ b/tests/unit/release/serializer-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | release', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('release');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = run(() => store.createRecord('release', {}));
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});


### PR DESCRIPTION
Adds `artist` model + serializer for relationships.

Example artist 'Nirvana' https://deploy-preview-14--explorer-discogs.netlify.com/artists/125246
Example artist 'Dave Grohl' https://deploy-preview-14--explorer-discogs.netlify.com/artists/203017

Notice how they have a few different fields.. 

Closes #6 