### PR TITLE
feat: add artistReleases model, same as label

### DIFF
--- a/app/artist-releases/adapter.js
+++ b/app/artist-releases/adapter.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from '../application/adapter';
+
+export default ApplicationAdapter.extend({
+  urlForFindRecord (id, modelName, snapshot) {
+    let baseUrl = this.buildURL('artists', id, snapshot);
+    return `${baseUrl}/releases`;
+  }
+});

--- a/app/artist-releases/model.js
+++ b/app/artist-releases/model.js
@@ -1,0 +1,5 @@
+import LabelReleaseModel from '../label-releases/model';
+
+export default LabelReleaseModel.extend({
+
+});

--- a/app/artist-releases/serializer.js
+++ b/app/artist-releases/serializer.js
@@ -1,0 +1,3 @@
+import LabelReleaseSerializer  from '../label-releases/serializer';
+
+export default LabelReleaseSerializer .extend({});

--- a/app/artist/model.js
+++ b/app/artist/model.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   members: DS.hasMany('artist', {inverse: null}),
   groups: DS.hasMany('artist', {inverse: null}),
   aliases: DS.hasMany('artist', {inverse: null}),
+  artistReleases: DS.belongsTo('artistReleases', {inverse: null, async: true}),
 
   name: DS.attr('string'),
   realname: DS.attr('string'),

--- a/app/artist/serializer.js
+++ b/app/artist/serializer.js
@@ -1,5 +1,11 @@
 import Serializer from '../application/serializer'
 
+const extractUrls = (payload) => {
+  return Object.assign(payload, {
+    artistReleases: payload.id
+  });
+};
+
 export default Serializer.extend({
   normalizeFindRecordResponse(store, primaryModelClass, payload, id, requestType) {
     let newPayload = payload
@@ -15,6 +21,8 @@ export default Serializer.extend({
     if (payload.groups) {
       newPayload.groups = payload.groups.map(artist => artist.id)
     }
+
+    let normalizedPayload = extractUrls(newPayload);
 
     return this._super(store, primaryModelClass, newPayload, id, requestType)
   }

--- a/app/artist/template.hbs
+++ b/app/artist/template.hbs
@@ -12,12 +12,17 @@
 {{/if}}
 
 {{#if model.namevariations}}
-<h3>Name variations</h3>
-{{each-list list=model.namevariations}}
+  <h3>Name variations</h3>
+  {{each-list list=model.namevariations}}
 {{/if}}
 
-<h3>Releases</h3>
-<p>releasesUrl: {{model.releasesUrl}}</p>
+{{#if model.artistReleases}}
+  <h3>Releases</h3>
+  <p>releasesUrl: {{model.releasesUrl}}</p>
+  {{#each-list list=model.artistReleases.releases as |item|}}
+    {{link-to item.title "release" item.id}}
+  {{/each-list}}
+{{/if}}
 
 {{#if model.members}}
 <h3>Members (artists)</h3>

--- a/app/components/media-player/template.hbs
+++ b/app/components/media-player/template.hbs
@@ -1,0 +1,3 @@
+<radio4000-player></radio4000-player>
+
+{{yield}}

--- a/tests/unit/artist-releases/adapter-test.js
+++ b/tests/unit/artist-releases/adapter-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | artist releases', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let adapter = this.owner.lookup('adapter:artist-releases');
+    assert.ok(adapter);
+  });
+});

--- a/tests/unit/artist-releases/model-test.js
+++ b/tests/unit/artist-releases/model-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | artist releases', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = run(() => store.createRecord('artist-releases', {}));
+    assert.ok(model);
+  });
+});

--- a/tests/unit/artist-releases/serializer-test.js
+++ b/tests/unit/artist-releases/serializer-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | artist releases', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('artist-releases');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = run(() => store.createRecord('artist-releases', {}));
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});


### PR DESCRIPTION
The same way the `labelReleases` model works, we implement an `artistReleases` model to fetch and display all releases from an artist