### PR TITLE
Feat/search filter

### DIFF
--- a/app/components/search-filter/component.js
+++ b/app/components/search-filter/component.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: 'span',
+
+  init() {
+    this._super(...arguments)
+    // Model for building the search filter.
+    const types = [
+      {label: 'All', value: ''},
+      {label: 'Releases', value: 'release'},
+      {label: 'Masters', value: 'master'},
+      {label: 'Artists', value: 'artist'},
+      {label: 'Labels', value: 'label'}
+    ]
+    this.set('types', types)
+  }
+});

--- a/app/components/search-filter/template.hbs
+++ b/app/components/search-filter/template.hbs
@@ -1,0 +1,28 @@
+{{#unless ui}}
+  <select onchange={{action (mut type) value="target.value"}}>
+    {{#each types as |t|}}
+      <option value={{t.value}} selected={{eq type t.value}}>
+      {{t.label}}
+      </option>
+    {{/each}}
+  </select>
+{{/unless}}
+
+{{#if (eq ui "buttons")}}
+  {{#each types as |t|}}
+    <button onclick={{action (mut type) t.value}} class="{{eq type t.value 'active'}}">
+    {{t.label}}
+    </button>
+  {{/each}}
+{{/if}}
+
+{{#if (eq ui "radio")}}
+  {{#each types as |t|}}
+    <label>
+      <input type="radio" name="searchType" checked={{eq type t.value}} value={{t.value}} onclick={{action (mut type) value="target.value"}}>
+      {{t.label}}
+    </label><br>
+  {{/each}}
+{{/if}}
+
+{{yield}}

--- a/app/components/search-head/component.js
+++ b/app/components/search-head/component.js
@@ -11,7 +11,10 @@ export default Component.extend({
   submit(event) {
     event.preventDefault()
     this.get('router').transitionTo('search', {
-      queryParams: {query: this.query}
+      queryParams: {
+        query: this.query,
+        type: this.type
+      }
     })
   }
 });

--- a/app/components/search-head/component.js
+++ b/app/components/search-head/component.js
@@ -2,13 +2,15 @@ import Component from '@ember/component';
 import {inject} from '@ember/service'
 
 export default Component.extend({
-  tagName: 'form',
   router: inject(),
-  search: '',
+
+  tagName: 'form',
+  query: '',
+
   submit(event) {
     event.preventDefault()
     this.get('router').transitionTo('search', {
-      queryParams: {search: this.search}
+      queryParams: {query: this.query}
     })
   }
 });

--- a/app/components/search-head/component.js
+++ b/app/components/search-head/component.js
@@ -6,6 +6,7 @@ export default Component.extend({
 
   tagName: 'form',
   query: '',
+  type: '',
 
   submit(event) {
     event.preventDefault()

--- a/app/components/search-head/template.hbs
+++ b/app/components/search-head/template.hbs
@@ -1,5 +1,5 @@
   {{input
     type="search"
     placeholder='Search artists, labels and releases'
-    value=search}}
+    value=query}}
   <button type="submit">Search</button>

--- a/app/components/search-head/template.hbs
+++ b/app/components/search-head/template.hbs
@@ -1,5 +1,8 @@
-  {{input
-    type="search"
-    placeholder='Search artists, labels and releases'
-    value=query}}
-  <button type="submit">Search</button>
+{{input
+  type="search"
+  placeholder='Search artists, labels and releases'
+  value=query}}
+
+{{search-filter type=type}}
+
+<button type="submit">Search</button>

--- a/app/master/model.js
+++ b/app/master/model.js
@@ -8,7 +8,7 @@ export default DS.Model.extend({
   genres: DS.attr(),
   images: DS.attr(),
   lowestPrice: DS.attr('number'),
-  mainRelease: DS.belongsTo('release', {async: true}),
+  mainRelease: DS.belongsTo('release', {async: true, inverse: null}),
   mainReleaseUrl: DS.attr('string'),
   numForSale: DS.attr('number'),
   resourceUrl: DS.attr('string'),

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -9,18 +9,5 @@ export default Controller.extend({
   query: '',
   perPage: 50,
   page: 1,
-  totalPages: readOnly('model.meta.pagination.pages'),
-
-  init() {
-    this._super(...arguments)
-    // Model for building the search filter.
-    const types = [
-      {label: 'All', value: ''},
-      {label: 'Releases', value: 'release'},
-      {label: 'Masters', value: 'master'},
-      {label: 'Artists', value: 'artist'},
-      {label: 'Labels', value: 'label'}
-    ]
-    this.set('types', types)
-  }
+  totalPages: readOnly('model.meta.pagination.pages')
 })

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -1,10 +1,10 @@
-import Controller from '@ember/controller';
-import { readOnly } from '@ember/object/computed';
+import Controller from '@ember/controller'
+import {readOnly} from '@ember/object/computed'
 
 export default Controller.extend({
   queryParams: ['search', 'perPage', 'page'],
-  search: '',
   // discogs's default
+  query: '',
   perPage: 50,
   page: 1,
   totalPages: readOnly('model.meta.pagination.pages')

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -2,10 +2,25 @@ import Controller from '@ember/controller'
 import {readOnly} from '@ember/object/computed'
 
 export default Controller.extend({
-  queryParams: ['search', 'perPage', 'page'],
-  // discogs's default
+  queryParams: ['type', 'query', 'perPage', 'page'],
+
+  // Discogs's default
+  type: '',
   query: '',
   perPage: 50,
   page: 1,
-  totalPages: readOnly('model.meta.pagination.pages')
-});
+  totalPages: readOnly('model.meta.pagination.pages'),
+
+  init() {
+    this._super(...arguments)
+    // Model for building the search filter.
+    const types = [
+      {label: 'All', value: ''},
+      {label: 'Releases', value: 'release'},
+      {label: 'Masters', value: 'master'},
+      {label: 'Artists', value: 'artist'},
+      {label: 'Labels', value: 'label'}
+    ]
+    this.set('types', types)
+  }
+})

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -2,17 +2,15 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   queryParams: {
-    search: {
-      refreshModel: true
-    },
-    page: {
-      refreshModel: true
-    }
+    type: {refreshModel: true},
+    query: {refreshModel: true},
+    page: {refreshModel: true}
   },
   model(params) {
-    if (params.search) {
+    console.log(params)
+    if (params.query) {
       return this.get('store').query('searchQuery', {
-        q: params.search,
+        q: params.query,
         page: params.page,
         per_page: params.perPage
       });

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -12,7 +12,8 @@ export default Route.extend({
       return this.get('store').query('searchQuery', {
         q: params.query,
         page: params.page,
-        per_page: params.perPage
+        per_page: params.perPage,
+        type: params.type
       });
     }
   }

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,7 +1,26 @@
+<p>
+  <label>
+  Searching
+  <select onchange={{action (mut type) value="target.value"}}>
+    {{#each types as |t|}}
+      <option value={{t.value}} selected={{eq type t.value}}>
+        {{t.label}}
+      </option>
+    {{/each}}
+  </select>
+  for <em>{{query}}</em>
+  </label>
+</p>
+
 {{#if model}}
   {{#each-list model as |result|}}
-    <em>{{result.type}}</em> {{link-to result.title result.type result.id}}
-    <!-- <img src={{result.thumb}} alt={{result.title}} /> -->
+    {{#unless type}}<em>{{result.type}}</em>{{/unless}}
+    {{link-to result.title result.type result.id}}
+    {{!--
+    {{#if result.thumb}}
+      <img src={{result.thumb}} alt={{result.title}} height="16">
+    {{/if}}
+    --}}
   {{/each-list}}
 
   {{search-pagination

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,4 +1,8 @@
-<p>Searching <em>{{type}}s</em> for <strong>{{query}}</strong>.</p>
+<p>
+  Found {{model.length}}
+  {{#if (eq type "")}}results{{else}}<em>{{type}}s</em>{{/if}}
+  for <strong>{{query}}</strong>.
+</p>
 
 <p>
   {{!--

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,15 +1,10 @@
+<p>Searching <em>{{type}}s</em> for <strong>{{query}}</strong>.</p>
+
 <p>
-  <label>
-  Searching
-  <select onchange={{action (mut type) value="target.value"}}>
-    {{#each types as |t|}}
-      <option value={{t.value}} selected={{eq type t.value}}>
-        {{t.label}}
-      </option>
-    {{/each}}
-  </select>
-  for <em>{{query}}</em>
-  </label>
+  {{!--
+  {{search-filter type=type ui="buttons"}}
+  --}}
+  {{search-filter type=type ui="radio"}}
 </p>
 
 {{#if model}}

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,0 +1,14 @@
+import {module, test} from 'qunit'
+import {visit, currentURL, fillIn, click} from '@ember/test-helpers'
+import {setupApplicationTest} from 'ember-qunit'
+
+module('Acceptance | search', function(hooks) {
+  setupApplicationTest(hooks)
+
+  test('searching in the header redirects to /search', async function(assert) {
+    await visit('/')
+    await fillIn('input[type="search"]', 'ryuichi sakamoto')
+    await click('button[type="submit"]')
+    assert.equal(currentURL(), '/search?query=ryuichi%20sakamoto')
+  })
+})

--- a/tests/integration/components/search-filter/component-test.js
+++ b/tests/integration/components/search-filter/component-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | search-filter', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with <select> by default', async function(assert) {
+    await render(hbs`{{search-filter}}`);
+    assert.ok(this.element.querySelector('select'))
+  });
+
+  test('it can switch to <button>s', async function(assert) {
+    await render(hbs`{{search-filter ui="buttons"}}`);
+    assert.equal(this.element.querySelectorAll('button').length, 5)
+  });
+
+  test('it can switch to input radio buttons', async function(assert) {
+    await render(hbs`{{search-filter ui="radio"}}`);
+    assert.equal(this.element.querySelectorAll('input[type="radio"]').length,  5)
+  });
+});


### PR DESCRIPTION
Added a `type` query param to the `search` route and a `<select>` to change it. By default it searches everything, like now.

You could argue that it should also be possible to filter in the search-form in the header, but I couldn't find a good UI.

Closes #37 