### PR TITLE
Add formatting to profile fields for artists

### DIFF
--- a/app/artist/info/template.hbs
+++ b/app/artist/info/template.hbs
@@ -1,7 +1,7 @@
 {{outlet}}
 
 <h3>Profile</h3>
-{{{model.profileDynamic}}}
+{{{format-profile model.profileDynamic}}}
 
 {{#if model.realname}}
   <h3>Real name</h3>

--- a/app/artist/info/template.hbs
+++ b/app/artist/info/template.hbs
@@ -1,8 +1,7 @@
 {{outlet}}
 
-{{#if model.profile}}
-  <p>{{model.profile}}</p>
-{{/if}}
+<h3>Profile</h3>
+{{{model.profileDynamic}}}
 
 {{#if model.realname}}
   <h3>Real name</h3>

--- a/app/artist/model.js
+++ b/app/artist/model.js
@@ -14,10 +14,19 @@ export default DS.Model.extend({
   realname: DS.attr('string'),
   namevariations: DS.attr(),
   profile: DS.attr('string'),
+  profileHtml: DS.attr('string'),
+  profilePlaintext: DS.attr('string'),
   releasesUrl: DS.attr('string'),
   resourceUrl: DS.attr('string'),
   uri: DS.attr('string'),
   urls: DS.attr(),
+
+  // Returns in priority HTML, plaintext or just profile
+  profileDynamic: computed('profile', 'profileHtml', 'profilePlaintext', function () {
+    const {profile, profileHtml, profilePlaintext} = this
+    if (!profileHtml && !profilePlaintext) return profile
+    return profileHtml ? profileHtml : profilePlaintext
+  }),
 
   discogsHumanUrl: computed('id', function() {
     return `https://discogs.com/artist/${this.get('id')}`;

--- a/app/helpers/format-profile.js
+++ b/app/helpers/format-profile.js
@@ -1,0 +1,14 @@
+import {helper} from '@ember/component/helper'
+
+const hrefRegex = /href="(.*?)"/gm
+const typeAndIdRegex = /([a-z]+(?:\/))([0-9]+(?:$|(?=[?-])|(?=\/$)))/gm
+
+export function formatProfile([profile]) {
+  return profile.replace(hrefRegex, (href) => {
+    let [typeAndId] = href.match(typeAndIdRegex)
+    const [type, id] = typeAndId.split('/')
+    return `href="/${type}s/${id}"`
+  })
+}
+
+export default helper(formatProfile)

--- a/app/helpers/format-profile.js
+++ b/app/helpers/format-profile.js
@@ -1,11 +1,11 @@
 import {helper} from '@ember/component/helper'
 
 const hrefRegex = /href="(.*?)"/gm
-const typeAndIdRegex = /([a-z]+(?:\/))([0-9]+(?:$|(?=[?-])|(?=\/$)))/gm
+const typeAndIdFromUrlRegex = /([a-z]+(?:\/))([0-9]+(?:$|(?=[?-])|(?=\/$)))/gm
 
 export function formatProfile([profile]) {
   return profile.replace(hrefRegex, (href) => {
-    let [typeAndId] = href.match(typeAndIdRegex)
+    let [typeAndId] = href.match(typeAndIdFromUrlRegex)
     const [type, id] = typeAndId.split('/')
     return `href="/${type}s/${id}"`
   })

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -5,6 +5,7 @@
   {{link-to "Example label" "label" "8377"}}<br>
   {{link-to "Example master" "master" "74177"}}<br>
   {{link-to "Example artist" "artist" "285231"}}<br>
+  {{link-to "Michael Jackson artist" "artist" "15885"}}<br>
 </p>
 
 {{outlet}}

--- a/tests/integration/helpers/format-profile-test.js
+++ b/tests/integration/helpers/format-profile-test.js
@@ -1,0 +1,18 @@
+import {module, test} from 'qunit'
+import {setupRenderingTest} from 'ember-qunit'
+import {render} from '@ember/test-helpers'
+import hbs from 'htmlbars-inline-precompile'
+
+const profileHtml = `Jackson began his career as the youngest member of <a href="https://www.discogs.com/artist/41157-The-Jackson-5" target="_blank">The Jackson 5</a> and started his solo recording career in 1971. Brother of recording artists <a href="https://www.discogs.com/artist/18948-Jackie-Jackson" target="_blank">Jackie Jackson</a>, <a href="https://www.discogs.com/artist/8024-Janet-Jackson" target="_blank">Janet Jackson</a>, <a href="https://www.discogs.com/artist/17971-Jermaine-Jackson" target="_blank">Jermaine Jackson</a>, <a href="https://www.discogs.com/artist/187011-La-Toya-Jackson" target="_blank">La Toya Jackson</a>, <a href="https://www.discogs.com/artist/284531-Marlon-Jackson" target="_blank">Marlon Jackson</a>, <a href="https://www.discogs.com/artist/239453-Randy-Jackson" target="_blank">Randy Jackson</a>, <a href="https://www.discogs.com/artist/115897-Rebbie-Jackson" target="_blank">Rebbie Jackson</a> &amp; <a href="https://www.discogs.com/artist/175556-Tito-Jackson" target="_blank">Tito Jackson</a>, as well as uncle of <a href="https://www.discogs.com/artist/64706-3T" target="_blank">3T</a>.`
+
+const profileHtmlExpected = `Jackson began his career as the youngest member of <a href="/artists/41157" target="_blank">The Jackson 5</a> and started his solo recording career in 1971. Brother of recording artists <a href="/artists/18948" target="_blank">Jackie Jackson</a>, <a href="/artists/8024" target="_blank">Janet Jackson</a>, <a href="/artists/17971" target="_blank">Jermaine Jackson</a>, <a href="/artists/187011" target="_blank">La Toya Jackson</a>, <a href="/artists/284531" target="_blank">Marlon Jackson</a>, <a href="/artists/239453" target="_blank">Randy Jackson</a>, <a href="/artists/115897" target="_blank">Rebbie Jackson</a> &amp; <a href="/artists/175556" target="_blank">Tito Jackson</a>, as well as uncle of <a href="/artists/64706" target="_blank">3T</a>.`
+
+module('Integration | Helper | format-profile', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it changes discogs links to local links', async function(assert) {
+    this.set('inputValue', profileHtml)
+    await render(hbs`{{format-profile inputValue}}`)
+    assert.equal(this.element.textContent.trim(), profileHtmlExpected)
+  })
+})


### PR DESCRIPTION
I configured the API to return HTML for "profile" field.

I did it with a computed property on the model that returns whichever profile field is available, prefering HTML or plaintext to the bbcode.

Other models also need it but I did not feel like creating a shared model or component yet. Thoughts?

Example https://deploy-preview-47--explorer-discogs.netlify.com/artists/15885/info